### PR TITLE
- "vcd_nsxt_network_dhcp" Module Release 2.0.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@
 *.tfstate.*
 secrets.tfvars
 secrets.auto.tfvars
+terraform.tfvars
+terraform.auto.tfvars
 providers.tf
 
 # Crash log files

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ This Terraform module deploys NSX-T DHCP Pools into an existing VMware Cloud Dir
 
 ```terraform
 module "vcd_nsxt_network_dhcp" {
-  source = "github.com/global-vmware/vcd_nsxt_network_dhcp.git?ref=v2.0.0"
+  source = "github.com/global-vmware/vcd_nsxt_network_dhcp.git?ref=v2.0.1"
 
   vdc_org_name   = "<VDC-ORG-NAME>"
   vdc_group_name = "<VDC-GRP-NAME>"

--- a/main.tf
+++ b/main.tf
@@ -11,6 +11,7 @@ terraform {
 
 # Create the Datacenter Group data source
 data "vcd_vdc_group" "dcgroup" {
+  org             = var.vdc_org_name
   name            = var.vdc_group_name
 }
 
@@ -23,8 +24,8 @@ data "vcd_nsxt_edgegateway" "t1" {
 
 data "vcd_network_routed_v2" "network" {
   for_each        = var.segments
-  name            = each.key
   org             = var.vdc_org_name
+  name            = each.key
   edge_gateway_id = data.vcd_nsxt_edgegateway.t1.id
 }
 


### PR DESCRIPTION
- "vcd_nsxt_network_dhcp" Module Release 2.0.1

- Added the "org" Argument to the "vcd_vdc_group" Data Source

- Updated the source URL Reference in the "vcd_nsxt_network_dhcp" Module Code Snippet to Version 2.0.1 in the Example Usage Section of the README